### PR TITLE
Remove forward declarations to cgo exported funcs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,4 +55,4 @@ https://pkg.go.dev/github.com/go-llsqlite/llsqlite
 
 ## Platform specific considerations
 
-By default it requires some pthreads DLL on Windows. To avoid it, supply `CGOLDFLAGS="-static"` when building your application.
+By default it requires some pthreads DLL on Windows. To avoid it, supply `CGO_LDFLAGS="-static"` when building your application.

--- a/auth.go
+++ b/auth.go
@@ -2,10 +2,8 @@ package sqlite
 
 // #include <stdint.h>
 // #include <sqlite3.h>
-// extern int go_sqlite_auth_tramp(uintptr_t, int, char*, char*, char*, char*);
-// static int c_auth_tramp(void *userData, int action, const char* arg1, const char* arg2, const char* db, const char* trigger) {
-//   return go_sqlite_auth_tramp((uintptr_t)userData, action, (char*)arg1, (char*)arg2, (char*)db, (char*)trigger);
-// }
+// #include "wrappers.h"
+//
 // static int sqlite3_go_set_authorizer(sqlite3* conn, uintptr_t id) {
 //   return sqlite3_set_authorizer(conn, c_auth_tramp, (void*)id);
 // }

--- a/func.go
+++ b/func.go
@@ -19,10 +19,6 @@ package sqlite
 // #include <sqlite3.h>
 // #include "wrappers.h"
 //
-// extern void func_tramp(sqlite3_context*, int, sqlite3_value**);
-// extern void step_tramp(sqlite3_context*, int, sqlite3_value**);
-// extern void final_tramp(sqlite3_context*);
-//
 // static int go_sqlite3_create_function_v2(
 //   sqlite3 *db,
 //   const char *zFunctionName,
@@ -170,10 +166,10 @@ func (conn *Conn) CreateFunction(name string, deterministic bool, numArgs int, x
 
 	var funcfn, stepfn, finalfn *[0]byte
 	if xFunc == nil {
-		stepfn = (*[0]byte)(C.step_tramp)
-		finalfn = (*[0]byte)(C.final_tramp)
+		stepfn = (*[0]byte)(C.c_step_tramp)
+		finalfn = (*[0]byte)(C.c_final_tramp)
 	} else {
-		funcfn = (*[0]byte)(C.func_tramp)
+		funcfn = (*[0]byte)(C.c_func_tramp)
 	}
 
 	res := C.go_sqlite3_create_function_v2(
@@ -200,8 +196,8 @@ func getxfuncs(ctx *C.sqlite3_context) *xfunc {
 	return x
 }
 
-//export func_tramp
-func func_tramp(ctx *C.sqlite3_context, n C.int, valarray **C.sqlite3_value) {
+//export go_func_tramp
+func go_func_tramp(ctx *C.sqlite3_context, n C.int, valarray **C.sqlite3_value) {
 	x := getxfuncs(ctx)
 	var vals []Value
 	if n > 0 {
@@ -210,8 +206,8 @@ func func_tramp(ctx *C.sqlite3_context, n C.int, valarray **C.sqlite3_value) {
 	x.xFunc(Context{ptr: ctx}, vals...)
 }
 
-//export step_tramp
-func step_tramp(ctx *C.sqlite3_context, n C.int, valarray **C.sqlite3_value) {
+//export go_step_tramp
+func go_step_tramp(ctx *C.sqlite3_context, n C.int, valarray **C.sqlite3_value) {
 	x := getxfuncs(ctx)
 	var vals []Value
 	if n > 0 {
@@ -220,8 +216,8 @@ func step_tramp(ctx *C.sqlite3_context, n C.int, valarray **C.sqlite3_value) {
 	x.xStep(Context{ptr: ctx}, vals...)
 }
 
-//export final_tramp
-func final_tramp(ctx *C.sqlite3_context) {
+//export go_final_tramp
+func go_final_tramp(ctx *C.sqlite3_context) {
 	x := getxfuncs(ctx)
 	x.xFinal(Context{ptr: ctx})
 }

--- a/session.go
+++ b/session.go
@@ -19,9 +19,6 @@ package sqlite
 // #include <sqlite3.h>
 // #include "wrappers.h"
 //
-// extern int go_strm_w_tramp(uintptr_t, char*, int);
-// extern int go_strm_r_tramp(uintptr_t, char*, int*);
-//
 // static int go_sqlite3session_changeset_strm(
 //   sqlite3_session *pSession,
 //   int (*xOutput)(void *pOut, const void *pData, int nData),

--- a/sqlite.go
+++ b/sqlite.go
@@ -68,16 +68,13 @@ static int transient_bind_blob(sqlite3_stmt* stmt, int col, unsigned char* p, in
 	return sqlite3_bind_blob(stmt, col, p, n, SQLITE_TRANSIENT);
 }
 
-extern void log_fn(void* pArg, int code, char* msg);
 static void enable_logging() {
-	sqlite3_config(SQLITE_CONFIG_LOG, log_fn, NULL);
+	sqlite3_config(SQLITE_CONFIG_LOG, c_log_fn, NULL);
 }
 
 static int db_config_onoff(sqlite3* db, int op, int onoff) {
   return sqlite3_db_config(db, op, onoff, NULL);
 }
-
-extern int goBusyHandlerCallback(void *, int);
 */
 import "C"
 
@@ -399,7 +396,7 @@ func (c *Conn) setBusyHandler(handler func(count int) bool) {
 		return
 	}
 	busyHandlers.Store(c.conn, handler)
-	C.sqlite3_busy_handler(c.conn, (*[0]byte)(C.goBusyHandlerCallback), unsafe.Pointer(c.conn))
+	C.sqlite3_busy_handler(c.conn, (*[0]byte)(C.c_goBusyHandlerCallback), unsafe.Pointer(c.conn))
 }
 
 //export goBusyHandlerCallback
@@ -1328,8 +1325,8 @@ func sqliteInitFn() {
 	}
 }
 
-//export log_fn
-func log_fn(_ unsafe.Pointer, code C.int, msg *C.char) {
+//export go_log_fn
+func go_log_fn(_ unsafe.Pointer, code C.int, msg *C.char) {
 	var msgBytes []byte
 	if msg != nil {
 		str := C.GoString(msg) // TODO: do not copy msg.

--- a/wrappers.c
+++ b/wrappers.c
@@ -42,8 +42,37 @@ int c_xapply_filter_tramp(void* pCtx, const char* zTab) {
         return go_xapply_filter_tramp((uintptr_t)pCtx, (char*)zTab);
 }
 
+extern void go_func_tramp(sqlite3_context*, int, sqlite3_value**);
+void c_func_tramp(sqlite3_context* ctx, int n, sqlite3_value** valarray) {
+        return go_func_tramp(ctx, n, valarray);
+}
+
+extern void go_step_tramp(sqlite3_context*, int, sqlite3_value**);
+void c_step_tramp(sqlite3_context* ctx, int n, sqlite3_value** valarray) {
+        return go_step_tramp(ctx, n, valarray);
+}
+
+extern void go_final_tramp(sqlite3_context*);
+void c_final_tramp(sqlite3_context* ctx) {
+        return go_final_tramp(ctx);
+}
+
 extern void go_destroy_tramp(uintptr_t);
 void c_destroy_tramp(void* ptr) {
         return go_destroy_tramp((uintptr_t)ptr);
 }
 
+extern int go_sqlite_auth_tramp(uintptr_t, int, char*, char*, char*, char*);
+int c_auth_tramp(void *userData, int action, const char* arg1, const char* arg2, const char* db, const char* trigger) {
+        return go_sqlite_auth_tramp((uintptr_t)userData, action, (char*)arg1, (char*)arg2, (char*)db, (char*)trigger);
+}
+
+extern void go_log_fn(void*, int, char*);
+void c_log_fn(void* pArg, int code, char* msg) {
+        return go_log_fn(pArg, code, msg);
+}
+
+extern int goBusyHandlerCallback(void *, int);
+int c_goBusyHandlerCallback(void *pArg, int count) {
+        return goBusyHandlerCallback(pArg, count);
+}

--- a/wrappers.h
+++ b/wrappers.h
@@ -26,6 +26,14 @@ int c_strm_r_tramp(void*, const void*, int*);
 int c_xapply_conflict_tramp(void*, int, sqlite3_changeset_iter*);
 int c_xapply_filter_tramp(void*, const char*);
 
+void c_log_fn(void*, int, char*);
+int c_auth_tramp(void*, int, const char*, const char*, const char*, const char*);
+
+void c_func_tramp(sqlite3_context*, int, sqlite3_value**);
+void c_step_tramp(sqlite3_context*, int, sqlite3_value**);
+void c_final_tramp(sqlite3_context*);
 void c_destroy_tramp(void*);
+
+int c_goBusyHandlerCallback(void*, int);
 
 #endif // WRAPPERS_H


### PR DESCRIPTION
Parallel PR to https://github.com/crawshaw/sqlite/pull/146 -- I feel like this one has a better chance of being merged than the crawshaw repo :) 

Full details of the change in PR linked above.

tl;dr, fixes building on windows with clang, as well as a typo in readme.md