### PR TITLE
sqlite: add Conn.Serialize wrapping sqlite3_serialize

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -18,6 +18,7 @@ package sqlite
 // #include <stdlib.h>
 import "C"
 import (
+	"fmt"
 	"runtime"
 	"unsafe"
 )
@@ -130,4 +131,24 @@ func (b *Backup) Remaining() int {
 // https://www.sqlite.org/c3ref/backup_finish.html#sqlite3backuppagecount
 func (b *Backup) PageCount() int {
 	return int(C.sqlite3_backup_pagecount(b.ptr))
+}
+
+// Serialize returns a byte slice containing the complete contents of the
+// named database (use "" or "main" for the main database). The returned
+// slice is a Go-owned copy; the caller may use it freely.
+//
+// https://www.sqlite.org/c3ref/serialize.html
+func (c *Conn) Serialize(dbName string) ([]byte, error) {
+	cname := cmain
+	if dbName != "" && dbName != "main" {
+		cname = C.CString(dbName)
+		defer C.free(unsafe.Pointer(cname))
+	}
+	var size C.sqlite3_int64
+	p := C.sqlite3_serialize(c.conn, cname, &size, 0)
+	if p == nil {
+		return nil, fmt.Errorf("sqlite.Conn.Serialize: out of memory or unsupported")
+	}
+	defer C.sqlite3_free(unsafe.Pointer(p))
+	return C.GoBytes(unsafe.Pointer(p), C.int(size)), nil
 }

--- a/backup_test.go
+++ b/backup_test.go
@@ -15,6 +15,7 @@
 package sqlite_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/go-llsqlite/crawshaw"
@@ -33,6 +34,41 @@ func initSrc(t *testing.T) *sqlite.Conn {
 		t.Fatal(err)
 	}
 	return conn
+}
+
+func TestSerialize(t *testing.T) {
+	conn := initSrc(t)
+	defer conn.Close()
+
+	data, err := conn.Serialize("")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := os.CreateTemp("", "serialize-test-*.sqlite3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		t.Fatal(err)
+	}
+	f.Close()
+
+	conn2, err := sqlite.OpenConn(f.Name(), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn2.Close()
+
+	count, err := sqlitex.ResultInt(conn2.Prep(`SELECT count(*) FROM t;`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 2 {
+		t.Fatalf("expected 2 rows in serialized DB, got %d", count)
+	}
 }
 
 func TestBackup(t *testing.T) {


### PR DESCRIPTION
Returns the complete contents of a named database as a Go-owned []byte, freeing the SQLite-allocated buffer before returning.

This is entirely vibe coded. It's also something very trivial which helps doing backups if you have a service which uses sqlite, this way you can, for example, expose a /backup/db endpoint and then do curl localhost/backup/db | rustic backup --stdin.